### PR TITLE
Add endpoints /acl and /manageACL for groupfolders

### DIFF
--- a/src/nextcloud/api_wrappers/group_folders.py
+++ b/src/nextcloud/api_wrappers/group_folders.py
@@ -9,6 +9,7 @@ from nextcloud import base
 
 class GroupFolders(base.OCSv1ApiWrapper):
     """ GroupFolders API wrapper """
+
     API_URL = "/apps/groupfolders/folders"
     JSON_ABLE = False
 
@@ -102,26 +103,30 @@ class GroupFolders(base.OCSv1ApiWrapper):
         url = "/".join([str(fid), "mountpoint"])
         return self.requester.post(url, data={"mountpoint": mountpoint})
 
-    def toggle_acl(self, fid, state=1):
+    def toggle_acl(self, fid, acl=1):
         """
         Enable∕disable advanced ACL on given group folder
 
         :param fid (int/str): group folder id
-        :param state (int): 1 for enable, 0 for disable
+        :param acl (int): 1 for enable, 0 for disable
         """
         url = "/".join([str(fid), "acl"])
-        return self.requester.post(url, data={"acl": state})
+        return self.requester.post(url, data={"acl": acl})
 
-    def manage_acl(self, fid, uid, type_="user", addacl=1):
+    def manage_acl(self, fid, mapping_id, mapping_type="user", manage_acl=1):
         """
         Grant/Remove a group or user the ability to manage a groupfolders' advanced permissions
 
         :param fid (int/str): group folder id
-        :param uid (str): user id or group id
-        :param type_ (str): "user" or "group"
-        :param addacl (int): 0 to delete ACL, 1 to add ACL
+        :param mapping_id (str): user id or group id
+        :param mapping_type (str): "user" or "group"
+        :param manage_acl (int): 0 to delete ACL, 1 to add ACL
         :returns:  requester response
         """
         url = "/".join([str(fid), "manageACL"])
-        data = {"mappingType": type_, "manageAcl": addacl, "mappingId": uid}
+        data = {
+            "mappingType": mapping_type,
+            "manageAcl": manage_acl,
+            "mappingId": mapping_id,
+        }
         return self.requester.post(url, data=data)

--- a/src/nextcloud/api_wrappers/group_folders.py
+++ b/src/nextcloud/api_wrappers/group_folders.py
@@ -102,6 +102,16 @@ class GroupFolders(base.OCSv1ApiWrapper):
         url = "/".join([str(fid), "mountpoint"])
         return self.requester.post(url, data={"mountpoint": mountpoint})
 
+    def toggle_acl(self, fid, state=1):
+        """
+        Enable∕disable advanced ACL on given group folder
+
+        :param fid (int/str): group folder id
+        :param state (int): 1 for enable, 0 for disable
+        """
+        url = "/".join([str(fid), "acl"])
+        return self.requester.post(url, data={"acl": state})
+
     def manage_acl(self, fid, uid, type_="user", addacl=1):
         """
         Grant/Remove a group or user the ability to manage a groupfolders' advanced permissions

--- a/src/nextcloud/api_wrappers/group_folders.py
+++ b/src/nextcloud/api_wrappers/group_folders.py
@@ -101,3 +101,17 @@ class GroupFolders(base.OCSv1ApiWrapper):
         """
         url = "/".join([str(fid), "mountpoint"])
         return self.requester.post(url, data={"mountpoint": mountpoint})
+
+    def manage_acl(self, fid, uid, type_="user", addacl=1):
+        """
+        Grant/Remove a group or user the ability to manage a groupfolders' advanced permissions
+
+        :param fid (int/str): group folder id
+        :param uid (str): user id or group id
+        :param type_ (str): "user" or "group"
+        :param addacl (int): 0 to delete ACL, 1 to add ACL
+        :returns:  requester response
+        """
+        url = "/".join([str(fid), "manageACL"])
+        data = {"mappingType": type_, "manageAcl": addacl, "mappingId": uid}
+        return self.requester.post(url, data=data)

--- a/tests/test_group_folders.py
+++ b/tests/test_group_folders.py
@@ -168,7 +168,7 @@ class TestGroupFolders(BaseTestCase):
         assert res.data[str(group_folder_id)]["manage"][username]["type"] == "user"
 
         # revoke advanced ACL
-        self.nxc.manage_acl(group_folder_id, username, addacl=0)
+        self.nxc.manage_acl(group_folder_id, username, manage_acl=0)
         # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
         #res = self.nxc.get_group_folder(group_folder_id)
         # assert username not in res.data["manage"]
@@ -201,7 +201,7 @@ class TestGroupFolders(BaseTestCase):
         assert int(res.data['quota']) == QUOTA_UNLIMITED
 
         # grant advanced ACL
-        self.nxc.manage_acl(group_folder_id, admin_group_id, type_="group")
+        self.nxc.manage_acl(group_folder_id, admin_group_id, mapping_type="group")
         # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
         #res = self.nxc.get_group_folder(group_folder_id)
         # assert admin_group_id in res.data["manage"]
@@ -211,7 +211,7 @@ class TestGroupFolders(BaseTestCase):
         assert res.data[str(group_folder_id)]["manage"][admin_group_id]["type"] == "group"
 
         # revoke advanced ACL
-        self.nxc.manage_acl(group_folder_id, admin_group_id, type_="group", addacl=0)
+        self.nxc.manage_acl(group_folder_id, admin_group_id, mapping_type="group", manage_acl=0)
         # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
         #res = self.nxc.get_group_folder(group_folder_id)
         # assert admin_group_id not in res.data["manage"]
@@ -239,7 +239,7 @@ class TestGroupFolders(BaseTestCase):
         res = self.nxc.get_group_folder(group_folder_id)
         assert int(res.data['quota']) == QUOTA_UNLIMITED
 
-        self.nxc.toggle_acl(group_folder_id, state=1)
+        self.nxc.toggle_acl(group_folder_id, acl=1)
         # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
         #res = self.nxc.get_group_folder(group_folder_id)
         # assert admin_group_id not in res.data["manage"]
@@ -247,7 +247,7 @@ class TestGroupFolders(BaseTestCase):
         assert str(group_folder_id) in res.data
         assert "1" in res.data[str(group_folder_id)]["acl"]
 
-        self.nxc.toggle_acl(group_folder_id, state=0)
+        self.nxc.toggle_acl(group_folder_id, acl=0)
         # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
         #res = self.nxc.get_group_folder(group_folder_id)
         # assert admin_group_id not in res.data["manage"]

--- a/tests/test_group_folders.py
+++ b/tests/test_group_folders.py
@@ -137,7 +137,7 @@ class TestGroupFolders(BaseTestCase):
         # clear
         self.clear(nxc=self.nxc, group_ids=[group_id], group_folder_ids=[group_folder_id])
 
-    def test_manage_acl(self):
+    def test_grant_revoke_advanced_acl_to_user(self):
         # create group to share with
         group_id = 'test_folders_' + self.get_random_string(length=4)
         self.nxc.add_group(group_id)
@@ -157,25 +157,67 @@ class TestGroupFolders(BaseTestCase):
         res = self.nxc.get_group_folder(group_folder_id)
         assert int(res.data['quota']) == QUOTA_UNLIMITED
 
-        # define manager
+        # grant advanced ACL
         self.nxc.manage_acl(group_folder_id, username)
         # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
         #res = self.nxc.get_group_folder(group_folder_id)
         # assert username in res.data["manage"]
-
         res = self.nxc.get_group_folders()
         assert str(group_folder_id) in res.data
         assert username in res.data[str(group_folder_id)]["manage"]
         assert res.data[str(group_folder_id)]["manage"][username]["type"] == "user"
 
-        # set permissions
-        new_permission = Permission.READ + Permission.CREATE
-        res = self.nxc.set_permissions_to_group_folder(group_folder_id, group_id, new_permission)
+        # revoke advanced ACL
+        self.nxc.manage_acl(group_folder_id, username, addacl=0)
+        # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
+        #res = self.nxc.get_group_folder(group_folder_id)
+        # assert username not in res.data["manage"]
+        res = self.nxc.get_group_folders()
+        assert str(group_folder_id) in res.data
+        assert username not in res.data[str(group_folder_id)]["manage"]
+
+        # clear
+        self.clear(nxc=self.nxc, group_ids=[group_id], group_folder_ids=[group_folder_id])
+
+    def test_grant_revoke_advanced_acl_to_group(self):
+        # create group to share with
+        group_id = 'test_folders_' + self.get_random_string(length=4)
+        self.nxc.add_group(group_id)
+
+        # create a second group to manage advanced permissions
+        admin_group_id = 'admin_group_' + self.get_random_string(length=4)
+        self.nxc.add_group(admin_group_id)
+
+        # create new group folder
+        folder_mount_point = "test_folder_advanced_permissions_" + self.get_random_string(length=4)
+        res = self.nxc.create_group_folder(folder_mount_point)
         assert res.is_ok
-        assert res.data is True
-        # check if permissions changed
+        group_folder_id = res.data['id']
+
+        # add new group to folder
+        self.nxc.grant_access_to_group_folder(group_folder_id, group_id)
+        # assert permissions is ALL by default
         res = self.nxc.get_group_folder(group_folder_id)
-        assert str(res.data['groups'][group_id]) == str(new_permission)
+        assert int(res.data['quota']) == QUOTA_UNLIMITED
+
+        # grant advanced ACL
+        self.nxc.manage_acl(group_folder_id, admin_group_id, type_="group")
+        # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
+        #res = self.nxc.get_group_folder(group_folder_id)
+        # assert admin_group_id in res.data["manage"]
+        res = self.nxc.get_group_folders()
+        assert str(group_folder_id) in res.data
+        assert admin_group_id in res.data[str(group_folder_id)]["manage"]
+        assert res.data[str(group_folder_id)]["manage"][admin_group_id]["type"] == "group"
+
+        # revoke advanced ACL
+        self.nxc.manage_acl(group_folder_id, admin_group_id, type_="group", addacl=0)
+        # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
+        #res = self.nxc.get_group_folder(group_folder_id)
+        # assert admin_group_id not in res.data["manage"]
+        res = self.nxc.get_group_folders()
+        assert str(group_folder_id) in res.data
+        assert admin_group_id not in res.data[str(group_folder_id)]["manage"]
 
         # clear
         self.clear(nxc=self.nxc, group_ids=[group_id], group_folder_ids=[group_folder_id])

--- a/tests/test_group_folders.py
+++ b/tests/test_group_folders.py
@@ -221,3 +221,36 @@ class TestGroupFolders(BaseTestCase):
 
         # clear
         self.clear(nxc=self.nxc, group_ids=[group_id], group_folder_ids=[group_folder_id])
+
+    def test_toggle_advanced_acl(self):
+        # create group to share with
+        group_id = 'test_folders_' + self.get_random_string(length=4)
+        self.nxc.add_group(group_id)
+
+        # create new group folder
+        folder_mount_point = "test_folder_advanced_permissions_" + self.get_random_string(length=4)
+        res = self.nxc.create_group_folder(folder_mount_point)
+        assert res.is_ok
+        group_folder_id = res.data['id']
+
+        # add new group to folder
+        self.nxc.grant_access_to_group_folder(group_folder_id, group_id)
+        # assert permissions is ALL by default
+        res = self.nxc.get_group_folder(group_folder_id)
+        assert int(res.data['quota']) == QUOTA_UNLIMITED
+
+        self.nxc.toggle_acl(group_folder_id, state=1)
+        # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
+        #res = self.nxc.get_group_folder(group_folder_id)
+        # assert admin_group_id not in res.data["manage"]
+        res = self.nxc.get_group_folders()
+        assert str(group_folder_id) in res.data
+        assert "1" in res.data[str(group_folder_id)]["acl"]
+
+        self.nxc.toggle_acl(group_folder_id, state=0)
+        # XXX We have to wait for commit https://github.com/nextcloud/groupfolders/commit/1c3874e0b980
+        #res = self.nxc.get_group_folder(group_folder_id)
+        # assert admin_group_id not in res.data["manage"]
+        res = self.nxc.get_group_folders()
+        assert str(group_folder_id) in res.data
+        assert "1" not in res.data[str(group_folder_id)]["acl"]


### PR DESCRIPTION
- [x] test giving advanced ACL to a simple user 
- [x] test giving advanced ACL to a group
- [x] test revoking advanced ACL to a simple user 
- [x] test revoking advanced ACL to a group
- [x] test enabling/disabling advanced ACL